### PR TITLE
Do not wait for a keypress when run as a service.

### DIFF
--- a/Args.hs
+++ b/Args.hs
@@ -33,6 +33,7 @@ data Args
         , verboseinterpreter :: Bool
         , recompilecmd  :: String
         , magicname     :: String
+        , daemon        :: Bool
         }
         deriving (Show, Data, Typeable)
 
@@ -58,6 +59,7 @@ myargs = Args
         , verboseinterpreter = False                &= help "Verbose interpreter output in the browser"
         , recompilecmd  = "ghc -O" &= typ "COMMAND" &= help "Command to run before page generation. Default is 'ghc -O'."
         , magicname    = "a9xYf"  &= typ "VARNAME"  &= help "Magic variable name."
+        , daemon       = False                      &= help "Run as a service."
         }  &= summary ("activehs " ++ showVersion version ++ ", (C) 2010-2012 Péter Diviánszky")
            &= program "activehs"
 


### PR DESCRIPTION
It may work well if the server waits for a key to press when run on a desktop machine, but it will not work if it is run on a server.  On servers, processes are often run in a non-interactive "headless" state without a TTY attached.  That is why the application crashes there when it tries to read from the standard input on launch.

To fix this, introduce a dedicated flag, `--daemon` to make this behavior only optional.